### PR TITLE
fix: s/await/async & method call dots in sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ $ npm i @pkgjs/meet
 ```javascript
 const maker = require('@pkgjs/meet')
 
-;(await () => {
-  const issue = await maker.meetings..createNextMeeting(client, {
+;(async () => {
+  const issue = await maker.meetings.createNextMeeting(client, {
     owner: 'pkgjs',
     repo: 'meet',
     schedules: []


### PR DESCRIPTION
Prior to this commit, the code sample seen in the README had a couple errors, which have been corrected.

/cc @wesleytodd