### PR TITLE
fix: flip 'issueTitle' to `true` as a required config

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
   issueTemplate:
     description: 'A name of an issue template (found in .github/ISSUE_TEMPLATES)'
     default: 'meeting.md'
-    required: false
+    required: true
 outputs:
   issueNumber:
     description: 'If an issue was created, this will be its number'


### PR DESCRIPTION
Flips the YAML boolean to `true` for issueTitle being required since the Action crashes if you don't include a title. Less of a change and more of a reflection of reality.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
