### PR TITLE
branch rename master to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   pull_request_target:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Schedule meetings via a GitHub Action.  Creates issues based on a schedule and template.
 
-This repository is managed by the [Package Maintenance Working Group](https://github.com/nodejs/package-maintenance), see [Governance](https://github.com/nodejs/package-maintenance/blob/master/Governance.md).
+This repository is managed by the [Package Maintenance Working Group](https://github.com/nodejs/package-maintenance), see [Governance](https://github.com/nodejs/package-maintenance/blob/main/Governance.md).
 
 
 ## Usage


### PR DESCRIPTION
Renamed the `master` branch to `main` following the [GitHub guide](https://github.blog/changelog/2021-01-19-support-for-renaming-an-existing-branch/)

To update your local repository run:

```
git branch -m master main
git fetch origin
git branch -u origin/main main
```

Ref https://github.com/nodejs/package-maintenance/issues/445

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
