### PR TITLE
test: add test for shorthand transform

### DIFF
--- a/lib/conversions.js
+++ b/lib/conversions.js
@@ -25,6 +25,8 @@ const templates = {
   }
 }
 
+module.exports.templates = templates
+
 const convert = async function (template) {
   /*
     - things to add from cutenode/action-meeting

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@ const { suite, test } = require('mocha')
 const assert = require('assert')
 const { DateTime } = require('luxon')
 const pkg = require('../package.json')
+const { convert, templates } = require('../lib/conversions')
 const meetings = require('../lib/meetings')
 
 suite(`${pkg.name} unit`, () => {
@@ -17,4 +18,23 @@ suite(`${pkg.name} unit`, () => {
 
     assert.deepStrictEqual(next.toISO(), DateTime.fromISO('2020-04-16T13:00:00.0Z').toISO())
   })
+})
+
+test('shorthands transform', async () => {
+  templates.values.title = 'Test Meeting'
+  templates.values.agendaLabel = 'meeting-agenda'
+  templates.values.invitees = '@pkgjs/meet'
+  templates.values.observers = '@nodejs/package-maintenance'
+
+  const input = `# <!-- title -->
+<!-- agenda label -->
+<!-- invitees -->
+<!-- observers  -->`
+
+  const output = `# Test Meeting
+meeting-agenda
+@pkgjs/meet
+@nodejs/package-maintenance`
+
+  assert.equal(await convert(input), output)
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

~~I think the shorthands are really not working. I’ve created a simple test that would be good to add to verify this behavior. Maybe someone could create another PR to fix it?~~

This adds tests to verify the behavior of `convert`, which transforms the shorthands.