### PR TITLE
fix: log issue url

### DIFF
--- a/run.js
+++ b/run.js
@@ -104,6 +104,7 @@ const pkg = require('./package.json')
       })
       console.log(`Fetching issues for ${r.owner}/${r.repo}: Found ${_agendaIssues.length}`)
       for (const i of _agendaIssues) {
+        console.log(`Adding Issue: ${i.url}`)
         if (!agendaIssues.find((ii) => ii.url === i.url)) {
           agendaIssues.push(i)
           break


### PR DESCRIPTION
The previous logging PRs showed that the filter here was excluding some issues. When I curl the GH apis they seem to show the correct url in the api response but maybe something else is going on. This might be a good case for using a proper logger (not `console.log`) and adding a debug log flag.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
