### PR TITLE
Add time zone support for aligning with calendars

### DIFF
--- a/lib/meetings.js
+++ b/lib/meetings.js
@@ -19,7 +19,7 @@ module.exports.setMeetingIssueBody = async function (client, opts) {
 
 function getNextIssue (opts) {
   const now = opts.now || DateTime.utc()
-  const date = getNextScheduledMeeting(opts.schedules, now)
+  const date = getNextScheduledMeeting(opts.schedules, now, opts.zone)
   const title = typeof opts.issueTitle === 'function' ? opts.issueTitle({ date }) : opts.issueTitle
 
   const issue = {
@@ -70,11 +70,11 @@ const shouldCreateNextMeetingIssue = module.exports.shouldCreateNextMeetingIssue
   return issue
 }
 
-const getNextScheduledMeeting = module.exports.getNextScheduledMeeting = function (schedules = [], now = DateTime.utc()) {
+const getNextScheduledMeeting = module.exports.getNextScheduledMeeting = function (schedules = [], now = DateTime.utc(), zone = undefined) {
   return schedules
     .map((s = `${now}/P7D`) => {
       // Parse interval
-      const i = Interval.fromISO(s)
+      const i = Interval.fromISO(s, { zone })
       const d = i.toDuration()
 
       // Get datetime for next event after now

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,26 @@ suite(`${pkg.name} unit`, () => {
 
     assert.deepStrictEqual(next.toISO(), DateTime.fromISO('2020-04-16T13:00:00.0Z').toISO())
   })
+
+  test('process schedule with zone', () => {
+    const next = meetings.getNextScheduledMeeting(
+      ['2020-04-02T17:00:00.0Z/P7D'],
+      DateTime.fromISO('2021-01-01T00:00:00.0Z'),
+      'America/Los_Angeles'
+    )
+
+    assert.deepStrictEqual(next.toISO(), DateTime.fromISO('2021-01-07T09:00:00.000-08:00').toISO())
+  })
+
+  test('process schedule with zone in DST', () => {
+    const next = meetings.getNextScheduledMeeting(
+      ['2020-04-02T17:00:00.0Z/P7D'],
+      DateTime.fromISO('2021-04-01T00:00:00.0Z'),
+      'America/Los_Angeles'
+    )
+
+    assert.deepStrictEqual(next.toISO(), DateTime.fromISO('2021-04-01T10:00:00.000-07:00').toISO())
+  })
 })
 
 test('shorthands transform', async () => {


### PR DESCRIPTION
Allows `zone` to be specified so the meeting can follow local timezones and avoid having to switch for daylight savings twice a year.