### PR TITLE
💚 fix CI runs for fork PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
 
   testint:
     runs-on: ubuntu-latest
+    # only run if not a fork PR targeting main repo due to permissions
+    if: ${{ !(github.head_repo || github.event.pull_request.head.repo) || github.repository == (github.head_repo.full_name || github.event.pull_request.head.repo.full_name) }}
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js 24
@@ -35,9 +37,13 @@ jobs:
     - run: npm install
     - run: npm run test:integration
       env:
-          GITHUB_TOKEN: ${{ secrets.INT_TEST_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.INT_TEST_TOKEN != '' && secrets.INT_TEST_TOKEN || secrets.GITHUB_TOKEN }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_HEAD_REPO: ${{ github.head_repo && github.head_repo.full_name || github.event.pull_request.head.repo.full_name || '' }}
   action-in-action:
     runs-on: ubuntu-latest
+    # only run if not a fork PR targeting main repo due to permissions
+    if: ${{ !(github.head_repo || github.event.pull_request.head.repo) || github.repository == (github.head_repo.full_name || github.event.pull_request.head.repo.full_name) }}
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js 24
@@ -47,6 +53,9 @@ jobs:
     - run: npm install
     - uses: ./
       id: maker
+      env:
+        TEST_REPOS: ${{ github.repository != 'pkgjs/meet' && github.repository || 'pkgjs/meet,pkgjs/meet' }}
+        TEST_ORGS: ${{ github.repository != 'pkgjs/meet' && '' || 'pkgjs' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         schedules: 2020-04-02T17:00:00.0Z/P1D
@@ -56,7 +65,7 @@ jobs:
         agendaLabel: meeting-agenda-test
         meetingLink: https://github.com/pkgjs/meet
         createNotes: true
-        repos: pkgjs/meet,pkgjs/meet
-        orgs: pkgjs
+        repos: ${{ env.TEST_REPOS }}
+        orgs: ${{ env.TEST_ORGS }}
     - name: clean up issue
       run: node ./test/_close-issue.js ${{ secrets.GITHUB_TOKEN }} ${{ steps.maker.outputs.issueNumber }}

--- a/test/_close-issue.js
+++ b/test/_close-issue.js
@@ -6,10 +6,13 @@ const issues = require('../lib/issues')
   if (!issueNumber) {
     return
   }
-  console.log(`Closing test issue ${issueNumber}`)
 
   const client = getOctokit(token)
+  const repo = context.repo
+
+  console.log(`Closing test issue ${issueNumber} in ${repo.owner}/${repo.repo}`)
+
   await issues.closeIssue(client, issueNumber, {
-    ...context.repo
+    ...repo
   })
 })(process.argv)


### PR DESCRIPTION
fork PRs targeting main will never be able to pass integration tests or action-in-action due to the lack of permissions that fork action/workflow get:
    
- it will not have write permission on the main repo
- it will not have write permission on the wesleytodd/meeting-maker repo
- it will not have write permission on its own repo because it's running in the main repo context
    
therefore, if you want to see the integration tests and action-in-action test passing, then a PR needs to be created in the fork repo

tests passing in the fork repo:  https://github.com/ctcpip/meet/pull/25

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
